### PR TITLE
Fix: project won't build because of wrong header file extension

### DIFF
--- a/uavpf/include/uavpf/uavpf.h
+++ b/uavpf/include/uavpf/uavpf.h
@@ -3,5 +3,5 @@
 #include "uavpf/config.h"
 #include "uavpf/version.h"
 
-#include "uavpf/id/base_id.hpp"
+#include "uavpf/id/base_id.h"
 


### PR DESCRIPTION
### Changes
- Change header file extension in the main header file from .hpp  to .h so that everything builds well.

### Checklist
- [x] I have preformed a self-review of my code
- [x] I have added unit-tests for my code where possible
- [x] My code didn't break existing unit-tests

