### PR TITLE
feat: `sprintf`-like formatting for `std::string`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(flight_planning VERSION 0.0.1)
+project(flight_planning VERSION 0.1.0)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 

--- a/tests/uavpf_tests/CMakeLists.txt
+++ b/tests/uavpf_tests/CMakeLists.txt
@@ -5,6 +5,8 @@ add_executable(uavpf_tests)
 target_sources(
 	uavpf_tests
 	PRIVATE
+	"src/test_format_str.cpp"
+
 	"src/id/test_id_allocator.cpp"
 )
 

--- a/tests/uavpf_tests/src/test_format_str.cpp
+++ b/tests/uavpf_tests/src/test_format_str.cpp
@@ -1,0 +1,18 @@
+#include <catch2/catch_all.hpp>
+#include <uavpf/format_str.h>
+
+TEST_CASE("String formatting")
+{
+	SECTION("sprintf-like formatting")
+	{
+		std::string result = uavpf::FormatStr("%s - %d _ %f", "Whatever", 107, 10.5f);
+		REQUIRE(result == "Whatever - 107 _ 10.500000");
+	}
+
+	SECTION("Scientific notation")
+	{
+		std::string scientific = uavpf::FormatStr("%.1e", 1e-7f);
+		REQUIRE(scientific == "1.0e-07");
+	}
+}
+

--- a/uavpf/CMakeLists.txt
+++ b/uavpf/CMakeLists.txt
@@ -10,6 +10,7 @@ configure_file(
 target_sources(
 	uavpf
 	PRIVATE
+	"src/format_str.cpp"
 	"src/version.cpp"
 
 	"src/id/id_allocator.cpp"

--- a/uavpf/include/uavpf/format_str.h
+++ b/uavpf/include/uavpf/format_str.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdarg>
+
+#include <string>
+#include <string_view>
+
+namespace uavpf
+{
+	std::string FormatStr(std::string_view fmt, ...);
+	std::string FormatStrV(std::string_view fmt, va_list args);
+}
+

--- a/uavpf/include/uavpf/uavpf.h
+++ b/uavpf/include/uavpf/uavpf.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "uavpf/config.h"
+#include "uavpf/format_str.h"
 #include "uavpf/version.h"
 
 #include "uavpf/id/base_id.h"

--- a/uavpf/src/format_str.cpp
+++ b/uavpf/src/format_str.cpp
@@ -1,0 +1,47 @@
+#include "uavpf/format_str.h"
+
+#include <cstdio>
+
+#include <array>
+#include <vector>
+
+std::string uavpf::FormatStr(std::string_view fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	std::string result = FormatStrV(fmt, args);
+	va_end(args);
+
+	return result;
+}
+
+std::string uavpf::FormatStrV(std::string_view fmt, va_list args)
+{
+	constexpr size_t cOptimalBufferSize = 512;
+	std::array<char, cOptimalBufferSize> optimalBuffer;
+
+	va_list firstTryArgs;
+	va_copy(firstTryArgs, args);
+	size_t requiredSize = std::vsnprintf(
+		optimalBuffer.data(),
+		optimalBuffer.size(),
+		fmt.data(),
+		firstTryArgs);
+	va_end(firstTryArgs);
+	requiredSize++; // Include null-terminator.
+
+	if (requiredSize <= optimalBuffer.size())
+	{
+		return std::string(optimalBuffer.data());	
+	}
+
+	std::vector<char> worstCaseBuffer(requiredSize);
+	std::vsnprintf(
+		worstCaseBuffer.data(),
+		worstCaseBuffer.size(),
+		fmt.data(),
+		args);
+
+	return std::string(worstCaseBuffer.data());
+}
+


### PR DESCRIPTION
### Changes
- Implement `FormatStr` and `FormatStrV` functions that implement `sprintf`-like string formatting but for standard `std::string`.

### Checklist
- [x] I have preformed a self-review of my code
- [x] I have added unit-tests for my code where possible
- [x] My code didn't break existing unit-tests

