### PR TITLE
fix: window size in params structure is not updated on resize

### DIFF
--- a/editor/src/main.cpp
+++ b/editor/src/main.cpp
@@ -81,8 +81,8 @@ namespace editor
 				Info,
 				"Window '%s' is resized: %dx%d",
 				event.ResizedWindow->GetTitle().data(),
-				event.Width,
-				event.Height);
+				event.ResizedWindow->GetWidth(),
+				event.ResizedWindow->GetHeight());
 
 			return true;
 		}

--- a/editor/src/platform_sdl3/sdl3_platform_service.cpp
+++ b/editor/src/platform_sdl3/sdl3_platform_service.cpp
@@ -190,6 +190,8 @@ namespace editor
 		Sdl3Window* resizedWindow = FindRegisteredWindowByNativeWindowID(
 			nativeWindowID);
 
+		resizedWindow->SyncSizeWithNativeWindow();
+
 		mPlatformEventPublisher.Publish<WindowResizeEvent>(
 			EventPublishMode::Queued,
 			width,

--- a/editor/src/platform_sdl3/sdl3_window.cpp
+++ b/editor/src/platform_sdl3/sdl3_window.cpp
@@ -75,6 +75,24 @@ namespace editor
 		return mNativeWindow;
 	}
 
+	void Sdl3Window::SyncSizeWithNativeWindow()
+	{
+		int width = 0;
+		int height = 0;
+		if (!SDL_GetWindowSize(mNativeWindow, &width, &height))
+		{
+			UAVPF_LOG(
+				Application,
+				Error,
+				"Could not retrieve SDL3 window size: %s",
+				SDL_GetError());
+			return;
+		}
+
+		mParams.Width = width;
+		mParams.Height = height;
+	}
+
 	void Sdl3Window::CreateNativeWindow()
 	{
 		int32_t defaultWindowFlag = SDL_WINDOW_RESIZABLE;

--- a/editor/src/platform_sdl3/sdl3_window.h
+++ b/editor/src/platform_sdl3/sdl3_window.h
@@ -20,6 +20,8 @@ namespace editor
 
 		SDL_Window* GetNativeWindow() const;
 
+		void SyncSizeWithNativeWindow();
+
 	private:
 		void CreateNativeWindow();
 		void DestroyNativeWindow();


### PR DESCRIPTION
### Changes
- Fixed `Sdl3Window::mParams` not being updated when `SDL_Window` is resized.

### Checklist
- [x] I have preformed a self-review of my code
- [x] My code didn't break existing unit-tests

